### PR TITLE
Add doctor management and frontend listing

### DIFF
--- a/app/Http/Controllers/Admin/DoctorController.php
+++ b/app/Http/Controllers/Admin/DoctorController.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Doctor;
+use Illuminate\Support\Facades\Validator;
+use Yajra\DataTables\DataTables;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class DoctorController extends Controller
+{
+    public function index()
+    {
+        return view('admin.Doctor.index');
+    }
+
+    public function save(Request $request)
+    {
+        $post = $request->post();
+        $hid = isset($post['hid']) ? intval($post['hid']) : null;
+        $response['status'] = 0;
+        $response['message'] = "Something went wrong!";
+
+        // Fields for validation
+        $fields = [
+            'name' => $request->name,
+            'specialization' => $request->specialization,
+            'image' => $request->file('image'),
+            'description' => $request->description,
+        ];
+
+        // Validation rules
+        $rules = [
+            'name' => 'required|max:191',
+            'specialization' => 'nullable|max:191',
+            'image' => $hid ? 'nullable|mimes:jpg,jpeg,png,gif|max:2048' : 'required|mimes:jpg,jpeg,png,gif|max:2048',
+            'description' => 'nullable',
+        ];
+
+        $validator = Validator::make($fields, $rules);
+
+        if (!$validator->fails()) {
+            if (!Storage::disk('public')->exists('doctor')) {
+                Storage::disk('public')->makeDirectory('doctor');
+            }
+
+            if ($hid) {
+                $imagePath = $request->file('image')
+                    ? $request->file('image')->store('doctor', 'public')
+                    : str_replace(asset('storage/') . '/', '', $request->old_image);
+            } else {
+                $imagePath = $request->file('image')
+                    ? $request->file('image')->store('doctor', 'public')
+                    : null;
+            }
+
+            $doctorData = [
+                'name' => $post['name'] ?? "",
+                'specialization' => $post['specialization'] ?? "",
+                'image' => $imagePath ?? "",
+                'description' => $post['description'] ?? "",
+            ];
+
+            if ($hid) {
+                $doctor = Doctor::where('id', $hid)->first();
+                if ($doctor) {
+                    $doctor->update($doctorData);
+                    $response['status'] = 1;
+                    $response['message'] = "Doctor updated successfully!";
+                } else {
+                    $response['message'] = "Doctor not found!";
+                }
+            } else {
+                if (Doctor::create($doctorData)) {
+                    $response['status'] = 1;
+                    $response['message'] = "Doctor added successfully!";
+                } else {
+                    $response['message'] = "Failed to add doctor!";
+                }
+            }
+        } else {
+            $response['message'] = $validator->errors()->first();
+        }
+
+        return response()->json($response);
+    }
+
+    public function doctorlist()
+    {
+        $doctor_data = Doctor::select('doctor.*')
+            ->where('doctor.is_deleted', '!=', 1)
+            ->orderBy('doctor.id', 'desc')
+            ->get();
+
+        return DataTables::of($doctor_data)
+            ->addIndexColumn()
+            ->addColumn('image', function ($row) {
+                if ($row->image) {
+                    return '<img src="' . asset("storage/$row->image") . '" alt="Image" width="50" height="50" />';
+                }
+                return '<span class="text-muted">No Image</span>';
+            })
+            ->addColumn('action', function ($row) {
+                $action = '<div class="dropdown dropup d-flex justify-content-center">'
+                    . '<button class="btn p-0" type="button" id="cardOpt3" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">'
+                    . '<i class="bx bx-dots-vertical-rounded"></i>'
+                    . '</button>'
+                    . '<div class="dropdown-menu dropdown-menu-end" aria-labelledby="cardOpt3">'
+                    . '<a class="teamroleDelete dropdown-item" href="javascript:void(0);" data-id="' . $row->id . '"><i class="bx bx-trash me-1"></i> Delete</a>'
+                    . '</div>'
+                    . '</div>'
+                    . '<div class="actions text-center">'
+                    . '<a class="btn btn-sm bg-success-light" data-toggle="modal" href="javascript:void(0);" id="edit_doctor" data-id="' . $row->id . '"><i class="fe fe-pencil"></i></a>'
+                    . '<a data-toggle="modal" class="btn btn-sm bg-danger-light" href="javascript:void(0);" id="delete_doctor" data-id="' . $row->id . '"><i class="fe fe-trash"></i></a>'
+                    . '</div>';
+                return $action;
+            })
+            ->rawColumns(['image', 'action'])
+            ->make(true);
+    }
+
+    public function delete(Request $request)
+    {
+        $post = $request->post();
+        $id = isset($post['id']) ? $post['id'] : "";
+        $response['status']  = 0;
+        $response['message']  = "Somthing Goes Wrong!";
+        if (is_numeric($id)) {
+            $delete_user = Doctor::where('id', $id)->update(['is_deleted' => 1]);
+            if ($delete_user) {
+                $response['status'] = 1;
+                $response['message'] = 'Doctor deleted successfully.';
+            } else {
+                $response['message'] = 'something went wrong.';
+            }
+        }
+        echo json_encode($response);
+        exit;
+    }
+
+    public function edit(Request $request)
+    {
+        $id = $request->query('id');
+        $response = [
+            'status' => 0,
+            'message' => 'Something went wrong!'
+        ];
+
+        if (is_numeric($id)) {
+            $doctor_data = Doctor::where('id', $id)->first();
+            if ($doctor_data) {
+                $doctor_data->image = $doctor_data->image ? asset("storage/$doctor_data->image") : null;
+                $response = [
+                    'status' => 1,
+                    'doctor_data' => $doctor_data
+                ];
+            }
+        }
+
+        return response()->json($response);
+    }
+}

--- a/app/Http/Controllers/CmsController.php
+++ b/app/Http/Controllers/CmsController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Cms;
+
+class CmsController extends Controller
+{
+    public function show(string $slug)
+    {
+        $page = Cms::where('slug', $slug)->where('status', 1)->firstOrFail();
+        return view('frontend.cms', compact('page'));
+    }
+}

--- a/app/Http/Controllers/DoctorController.php
+++ b/app/Http/Controllers/DoctorController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Doctor;
+
+class DoctorController extends Controller
+{
+    public function index()
+    {
+        $doctors = Doctor::where('is_deleted', '!=', 1)->orderBy('id', 'desc')->get();
+        return view('frontend.doctors', compact('doctors'));
+    }
+}

--- a/app/Models/Doctor.php
+++ b/app/Models/Doctor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Doctor extends Model
+{
+    use HasFactory;
+
+    protected $table = 'doctor';
+
+    protected $fillable = [
+        'name',
+        'specialization',
+        'image',
+        'description',
+        'is_deleted',
+        'created_by',
+        'updated_by',
+    ];
+
+    // Relationship with User (Creator)
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    // Relationship with User (Editor)
+    public function editor()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/database/migrations/2024_08_25_000000_create_doctor_table.php
+++ b/database/migrations/2024_08_25_000000_create_doctor_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('doctor', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('specialization')->nullable();
+            $table->string('image')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('is_deleted')->default(0);
+            $table->foreignId('created_by')->nullable();
+            $table->foreignId('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('doctor');
+    }
+};

--- a/public/assets/admin/theme/js/custom/Doctor.js
+++ b/public/assets/admin/theme/js/custom/Doctor.js
@@ -1,0 +1,155 @@
+$(document).ready(function() {
+    $.ajaxSetup({
+        headers: {
+            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+        }
+    });
+    $("#hid").val("");
+
+    $("#Add_doctors_details").on("hidden.bs.modal", function() {
+        $("#DoctorForm")[0].reset();
+        $("#hid").val("");
+        $("#DoctorForm").validate().resetForm();
+        $("#DoctorForm").find('.error').removeClass('error');
+        $("#image_preview").html('');
+    });
+
+    if ($.fn.DataTable.isDataTable('#DoctorTable')) {
+        $('#DoctorTable').DataTable().destroy();
+    }
+
+    $('#DoctorTable').dataTable({
+        searching: true,
+        paging: true,
+        pageLength: 10,
+        ajax: {
+            url: "/admin/doctorlist",
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                _token: $("[name='_token']").val(),
+            },
+        },
+        columns: [
+            { data: "name" },
+            { data: "specialization" },
+            { data: "image", orderable: false, searchable: false },
+            { data: "action", orderable: false, searchable: false }
+        ],
+    });
+});
+
+$(document).on('click', '#Add_doctors', function() {
+    $('#Add_doctors_details').modal('show');
+    $("#DoctorForm").find('.form-control').removeClass('error');
+    $("#DoctorForm").find('.error').remove();
+    $("#modal_title").html("Add Doctor");
+});
+
+var validationRules = {
+    name: { required: true, maxlength: 191 },
+    specialization: { maxlength: 191 },
+    image: {
+        required: function() {
+            return $('#hid').val() === "";
+        },
+        extension: "jpg|jpeg|png|gif"
+    }
+};
+
+var validationMessages = {
+    name: {
+        required: "Please enter the doctor's name",
+        maxlength: "Name cannot exceed 191 characters",
+    },
+    specialization: {
+        maxlength: "Specialization cannot exceed 191 characters",
+    },
+    image: {
+        required: "Please upload an image",
+        extension: "Only JPG, JPEG, PNG, or GIF formats are allowed",
+    }
+};
+
+$("#DoctorForm").validate({
+    rules: validationRules,
+    messages: validationMessages,
+    submitHandler: function(form) {
+        var formData = new FormData(form);
+        $.ajax({
+            type: "POST",
+            url: "/admin/doctor/save",
+            data: formData,
+            contentType: false,
+            processData: false,
+            success: function(response) {
+                if (response.status == 1) {
+                    $('#DoctorTable').DataTable().ajax.reload();
+                    $('#Add_doctors_details').modal('hide');
+                    toastr.success(response.message);
+                } else {
+                    toastr.error(response.message);
+                }
+            }
+        });
+        return false;
+    }
+});
+
+$(document).on("click", "#delete_doctor", function() {
+    let id = $(this).data("id");
+    Swal.fire({
+        title: "Are you sure?",
+        text: "You won't be able to revert this!",
+        icon: "warning",
+        showCancelButton: true,
+        confirmButtonColor: "#3085d6",
+        cancelButtonColor: "#d33",
+        confirmButtonText: "Yes, delete it!",
+    }).then((result) => {
+        if (result.isConfirmed) {
+            $.ajax({
+                type: "POST",
+                url: "/admin/doctor/delete",
+                data: {
+                    _token: $("[name='_token']").val(),
+                    id: id,
+                },
+                success: function(response) {
+                    var data = JSON.parse(response);
+                    if (data.status == 1) {
+                        $('#DoctorTable').DataTable().ajax.reload();
+                        toastr.success(data.message);
+                    } else {
+                        toastr.error(data.message);
+                    }
+                }
+            });
+        }
+    });
+});
+
+$(document).on('click', '#edit_doctor', function() {
+    let id = $(this).data('id');
+    $.ajax({
+        type: "GET",
+        url: "/admin/doctor/edit",
+        data: { id: id },
+        success: function(response) {
+            if (response.status == 1) {
+                let doctordata = response.doctor_data;
+                $('#hid').val(doctordata.id);
+                $('#name').val(doctordata.name);
+                $('#specialization').val(doctordata.specialization);
+                $('#old_image').val(doctordata.image || "");
+                if (doctordata.image) {
+                    $('#image_preview').html(`<img src="${doctordata.image}" alt="Image" width="100" height="100" class="mb-2">`);
+                } else {
+                    $('#image_preview').html('<span class="text-muted">No Image</span>');
+                }
+                $('#Add_doctors_details').modal('show');
+                $("#modal_title").html("Edit Doctor");
+            }
+        }
+    });
+});

--- a/resources/views/admin/Doctor/DoctorModal.blade.php
+++ b/resources/views/admin/Doctor/DoctorModal.blade.php
@@ -1,0 +1,57 @@
+<!-- Add Modal -->
+<div class="modal fade" id="Add_doctors_details" aria-hidden="true" role="dialog">
+    <div class="modal-dialog modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal_title">Add Doctor</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form onsubmit="return false" method="POST" id="DoctorForm" name="DoctorForm"
+                    enctype="multipart/form-data">
+                    @csrf
+                    <input type="hidden" id="hid" name="hid" value="">
+                    <input type="hidden" name="old_image" id="old_image">
+
+                    <div class="form-group row">
+                        <label class="col-lg-3 col-form-label">Name</label>
+                        <div class="col-lg-9">
+                            <input type="text" id="name" name="name" class="form-control"
+                                placeholder="Please enter name">
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label class="col-lg-3 col-form-label">Specialization</label>
+                        <div class="col-lg-9">
+                            <input type="text" id="specialization" name="specialization" class="form-control"
+                                placeholder="Please enter specialization">
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label class="col-lg-3 col-form-label">Image</label>
+                        <div class="col-lg-9">
+                            <input type="file" id="image" name="image" class="form-control">
+                            <div id="image_preview" class="mt-2"></div>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label class="col-lg-3 col-form-label">Description</label>
+                        <div class="col-lg-9">
+                            <textarea id="description" name="description" class="form-control" placeholder="Enter description"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="text-right">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- /ADD Modal -->

--- a/resources/views/admin/Doctor/index.blade.php
+++ b/resources/views/admin/Doctor/index.blade.php
@@ -1,0 +1,30 @@
+@extends('admin.layouts.index')
+@section('admin-title', 'Doctors')
+@section('page-title', 'List of Doctors')
+@section('add-button')
+    <div class="col-sm-5 col">
+        <a id="Add_doctors" data-toggle="modal" data-target="#Add_doctors_details"
+            class="btn btn-primary float-right mt-2 text-light">Add</a>
+    </div>
+@endsection
+@section('admin-content')
+    <div class="table-responsive">
+        <table class="datatable table table-hover mb-0" id="DoctorTable">
+            <thead class="text-left">
+                <tr>
+                    <th>Name</th>
+                    <th>Specialization</th>
+                    <th>Image</th>
+                    <th class="text-center">Action</th>
+                </tr>
+            </thead>
+            <tbody>
+
+            </tbody>
+        </table>
+    </div>
+    @include('admin.Doctor.DoctorModal')
+@endsection
+@section('admin-js')
+    <script src="{{ asset('assets/admin/theme/js/custom/Doctor.js') }}"></script>
+@endsection

--- a/resources/views/admin/layouts/sidebar.blade.php
+++ b/resources/views/admin/layouts/sidebar.blade.php
@@ -24,6 +24,12 @@
             'roles' => null,
         ],
         [
+            'route' => 'admin.doctor',
+            'icon' => 'fa-solid fa-user-doctor',
+            'label' => 'Doctors',
+            'roles' => null,
+        ],
+        [
             'route' => 'admin.cms',
             'icon' => 'fa-solid fa-cogs',
             'label' => 'Cms',

--- a/resources/views/frontend/cms.blade.php
+++ b/resources/views/frontend/cms.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mt-4">
+    <h1 class="mb-4">{{ $page->title }}</h1>
+    <div>{!! $page->description !!}</div>
+</div>
+@endsection

--- a/resources/views/frontend/doctors.blade.php
+++ b/resources/views/frontend/doctors.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mt-4">
+    <h1 class="mb-4">Our Doctors</h1>
+    <div class="row">
+        @foreach($doctors as $doctor)
+            <div class="col-md-4 mb-4">
+                <div class="card h-100">
+                    @if($doctor->image)
+                        <img src="{{ asset('storage/' . $doctor->image) }}" class="card-img-top" alt="{{ $doctor->name }}">
+                    @endif
+                    <div class="card-body">
+                        <h5 class="card-title">{{ $doctor->name }}</h5>
+                        <p class="card-text"><strong>{{ $doctor->specialization }}</strong></p>
+                        <p class="card-text">{{ $doctor->description }}</p>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -34,6 +34,22 @@
 </head>
 
 <body>
+    @php
+        $cmsPages = \App\Models\Cms::where('status', 1)->get();
+    @endphp
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container">
+            <a class="navbar-brand" href="{{ url('/') }}">Home</a>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav mr-auto">
+                    @foreach ($cmsPages as $page)
+                        <li class="nav-item"><a class="nav-link" href="{{ url($page->slug) }}">{{ $page->title }}</a></li>
+                    @endforeach
+                    <li class="nav-item"><a class="nav-link" href="{{ url('/doctors') }}">Doctors</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
     <div id="app">
         <main class="py-4">
             @yield('content')

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,13 @@ Route::middleware(['admin'])->prefix('admin')->group(function () {
     Route::get('/course/edit', [App\Http\Controllers\Admin\CourseController::class, 'edit'])->name('edit.course');
     Route::post('/course/delete', [App\Http\Controllers\Admin\CourseController::class, 'delete'])->name('delete.course');
 
+    // doctor
+    Route::get('/doctor', [App\Http\Controllers\Admin\DoctorController::class, 'index'])->name('admin.doctor');
+    Route::post('/doctorlist', [App\Http\Controllers\Admin\DoctorController::class, 'doctorlist'])->name('admin.doctorlist');
+    Route::post('/doctor/save', [App\Http\Controllers\Admin\DoctorController::class, 'save'])->name('save.doctor');
+    Route::get('/doctor/edit', [App\Http\Controllers\Admin\DoctorController::class, 'edit'])->name('edit.doctor');
+    Route::post('/doctor/delete', [App\Http\Controllers\Admin\DoctorController::class, 'delete'])->name('delete.doctor');
+
     //cms
     Route::get('/cms', [App\Http\Controllers\Admin\CmsController::class, 'index'])->name('admin.cms');
     Route::post('/cms/save', [App\Http\Controllers\Admin\CmsController::class, 'save'])->name('admin.cms.save');
@@ -46,3 +53,6 @@ Route::middleware(['admin'])->prefix('admin')->group(function () {
     Route::get('/settings/remove_logo', [App\Http\Controllers\Admin\SettingsController::class, 'remove_logo'])->name('remove_logo.settings');
     Route::get('/settings/remove_favicon', [App\Http\Controllers\Admin\SettingsController::class, 'remove_favicon'])->name('remove_favicon.settings');
 });
+
+Route::get('/doctors', [App\Http\Controllers\DoctorController::class, 'index'])->name('frontend.doctors');
+Route::get('/{slug}', [App\Http\Controllers\CmsController::class, 'show'])->name('frontend.cms');


### PR DESCRIPTION
## Summary
- create doctor database table and model
- implement admin doctor CRUD with modal, routes, and sidebar entry
- display doctors on public site with dynamic navigation linked to CMS pages

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0dea1428832c9d035e25c219407a